### PR TITLE
Tooling QoL improvements

### DIFF
--- a/packages/core-tools/README.md
+++ b/packages/core-tools/README.md
@@ -1,0 +1,3 @@
+# `@finch/core-tools`
+
+Contains responsibilities central to finch subpackage development.

--- a/packages/core-tools/lib/createExportAliasSpecs.js
+++ b/packages/core-tools/lib/createExportAliasSpecs.js
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+
+const path = require("path");
+const fs = require("fs");
+
+module.exports = function createExportAliasSpecs({ exportDirectory }) {
+  const aliases = fs
+    .readdirSync(exportDirectory)
+    .filter(filename => !/^\./.test(filename))
+    .filter(filename => /\.js$/.test(filename))
+    .filter(filename => !/spec\.js$/.test(filename))
+    .map(filename => filename.replace(/\.js$/, ""));
+
+  const lib = path.resolve(exportDirectory, "lib");
+
+  const modules = fs
+    .readdirSync(lib)
+    .filter(filename => !/^\./.test(filename))
+    .reduce((acc, filename) => {
+      const pathname = path.resolve(lib, filename);
+
+      if (fs.statSync(pathname).isDirectory()) {
+        acc.push(pathname);
+      }
+
+      return acc;
+    }, []);
+
+  // All aliases should have a module.
+  test.each(aliases)("alias %s has module", moduleName => {
+    const alias = require(path.join(exportDirectory, moduleName));
+    const actual = require(path.join(lib, moduleName));
+    // const actual = require(`./lib/${moduleName}/`);
+
+    expect(alias).toBe(actual);
+  });
+
+  // All modules should have an alias.
+  test.each(modules)("module %s has alias", file => {
+    const moduleName = file.split(path.sep).pop();
+    const alias = require(path.join(exportDirectory, moduleName));
+    const actual = require(file);
+
+    expect(alias).toBe(actual);
+  });
+};

--- a/packages/core-tools/lib/index.js
+++ b/packages/core-tools/lib/index.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("@mseeley/export-from")(__dirname);

--- a/packages/core-tools/package.json
+++ b/packages/core-tools/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@finch/core-tools",
+  "private": false,
+  "version": "0.0.0",
+  "description": "Contains responsibilities central to finch subpackage development.",
+  "author": "Matt Seeley <mattseeley@hotmail.com>",
+  "homepage": "https://github.com/mseeley/finch#readme",
+  "license": "MPL-2.0",
+  "main": "lib/index.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "files": [
+    "lib"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://mseeley@github.com/mseeley/finch.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  },
+  "bugs": {
+    "url": "https://github.com/mseeley/finch/issues"
+  },
+  "dependencies": {
+    "@mseeley/export-from": "0.1.1"
+  }
+}

--- a/scripts/create-cli.js
+++ b/scripts/create-cli.js
@@ -8,6 +8,7 @@ async function main() {
   try {
     const settings = await inquirer.prompt([
       questions.packageNameToOrgScopeNotExists,
+      questions.packageDescription,
       questions.isPrivate
     ]);
 

--- a/scripts/workspace/helpers/readReadme.js
+++ b/scripts/workspace/helpers/readReadme.js
@@ -1,0 +1,8 @@
+const fs = require("fs-extra");
+const resolveReadme = require("./resolveReadme");
+
+module.exports = async function readPackageJson({ packageName }) {
+  const file = await resolveReadme({ packageName });
+
+  return fs.readFile(file, { encoding: "utf8" });
+};

--- a/scripts/workspace/helpers/resolveReadme.js
+++ b/scripts/workspace/helpers/resolveReadme.js
@@ -1,0 +1,8 @@
+const path = require("path");
+const resolvePackage = require("./resolvePackage");
+
+module.exports = async function resolveReadme({ packageName }) {
+  const package = await resolvePackage({ packageName });
+
+  return path.resolve(package, "README.md");
+};

--- a/scripts/workspace/helpers/writeReadme.js
+++ b/scripts/workspace/helpers/writeReadme.js
@@ -1,0 +1,8 @@
+const fs = require("fs-extra");
+const resolveReadme = require("./resolveReadme");
+
+module.exports = async function writeReadme({ packageName, data }) {
+  const file = await resolveReadme({ packageName });
+
+  return fs.writeFile(file, data, { encoding: "utf8" });
+};

--- a/scripts/workspace/questions.js
+++ b/scripts/workspace/questions.js
@@ -118,7 +118,7 @@ async function validateString(value, answers) {
 
 question("packageName", {
   type: "input",
-  message: `Package:`,
+  message: "Package:",
   filter: [filterSanitizeString],
   validate: [validateString, validatePackageName]
 });
@@ -136,6 +136,13 @@ question("packageNameToOrgScopeExists", {
 question("packageNameToOrgScopeNotExists", {
   extends: "packageNameToOrgScope",
   validate: [validateString, validatePackageName, validatePackageNotExists]
+});
+
+question("packageDescription", {
+  type: "input",
+  message: "Description:",
+  filter: [filterSanitizeString],
+  validate: [validateString]
 });
 
 question("lernaScopeExists", {

--- a/scripts/workspace/template/README.md
+++ b/scripts/workspace/template/README.md
@@ -1,1 +1,3 @@
-> TODO: description
+# `{packageName}`
+
+{packageDescription}

--- a/scripts/workspace/template/lib/index.js
+++ b/scripts/workspace/template/lib/index.js
@@ -1,5 +1,3 @@
 "use strict";
 
-module.exports = function helloWorld() {
-  return "Hello world";
-};
+module.exports = require("@mseeley/export-from")(__dirname);

--- a/scripts/workspace/template/package.json
+++ b/scripts/workspace/template/package.json
@@ -2,7 +2,7 @@
   "name": "template",
   "private": true,
   "version": "0.0.0",
-  "description": "> TODO: description",
+  "description": "template",
   "author": "Matt Seeley <mattseeley@hotmail.com>",
   "homepage": "https://github.com/mseeley/finch#readme",
   "license": "MPL-2.0",
@@ -22,5 +22,8 @@
   },
   "bugs": {
     "url": "https://github.com/mseeley/finch/issues"
+  },
+  "dependencies": {
+    "@mseeley/export-from": "0.1.1"
   }
 }


### PR DESCRIPTION
- Make it easy to quickly/consistently spec package exports.
- Also replace some manual steps after `yarn new` is used to create a new sub-package.