### PR TITLE
(build) update eslint and prettier config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: [
     "@commitlint/config-conventional",
-    "@commitlint/config-lerna-scopes"
-  ]
+    "@commitlint/config-lerna-scopes",
+  ],
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,7 @@ module.exports = {
     "dot-notation": "error",
     "eol-last": "error",
     eqeqeq: ["error", "smart"],
+    "import/group-exports": "error",
     "import/named": "error",
     "import/no-absolute-path": "error",
     "import/no-extraneous-dependencies": "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2017,
     impliedStrict: true,
-    sourceType: "script"
+    sourceType: "script",
   },
 
   plugins: ["import", "prettier"],
@@ -15,7 +15,7 @@ module.exports = {
   env: {
     commonjs: true,
     es6: true,
-    node: true
+    node: true,
   },
 
   rules: {
@@ -38,10 +38,10 @@ module.exports = {
           "internal",
           "parent",
           "sibling",
-          "index"
+          "index",
         ],
-        "newlines-between": "never"
-      }
+        "newlines-between": "never",
+      },
     ],
     "linebreak-style": ["error", "unix"],
     "no-alert": 0,
@@ -76,7 +76,7 @@ module.exports = {
     "no-unneeded-ternary": "error",
     "no-unused-vars": [
       "error",
-      { vars: "all", args: "none", ignoreRestSiblings: true }
+      { vars: "all", args: "none", ignoreRestSiblings: true },
     ],
     "no-useless-call": "error",
     "no-useless-concat": "error",
@@ -85,6 +85,6 @@ module.exports = {
     "prefer-const": "error",
     "prettier/prettier": "error",
     radix: "error",
-    yoda: "error"
-  }
+    yoda: "error",
+  },
 };

--- a/husky.config.js
+++ b/husky.config.js
@@ -4,6 +4,6 @@ const tasks = (...arr) => arr.join(" && ");
 module.exports = {
   hooks: {
     "commit-msg": tasks("commitlint -E HUSKY_GIT_PARAMS"),
-    "pre-commit": tasks("lint-staged", "yarn test --ci")
-  }
+    "pre-commit": tasks("lint-staged", "yarn test --ci"),
+  },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -169,7 +169,7 @@ module.exports = {
   verbose: false,
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-  watchPathIgnorePatterns: ["node_modules"]
+  watchPathIgnorePatterns: ["node_modules"],
 
   // Whether to use watchman for file crawling
   // watchman: true,

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   "*.js": ["yarn eslint --fix", "git add"],
-  "*.{html|md}": ["yarn prettier --write", "git add"]
+  "*.{html|md}": ["yarn prettier --write", "git add"],
 };

--- a/packages/config/lib/helpers/readConfig/index.js
+++ b/packages/config/lib/helpers/readConfig/index.js
@@ -11,7 +11,7 @@ function formatOf(filename) {
 const parsers = {
   json: contents => JSON.parse(contents),
   yml: contents => yaml.safeLoad(contents, { json: true }),
-  yaml: contents => yaml.safeLoad(contents, { json: true })
+  yaml: contents => yaml.safeLoad(contents, { json: true }),
 };
 
 /**
@@ -79,6 +79,6 @@ module.exports = async function({ filename, sync = false }) {
 
   return {
     data: Object.keys(data).length ? data : null,
-    filename
+    filename,
   };
 };

--- a/packages/config/lib/helpers/readConfig/index.spec.js
+++ b/packages/config/lib/helpers/readConfig/index.spec.js
@@ -14,7 +14,7 @@ describe(localNameOf(__filename), () => {
       const data = await readFile({ filename });
       const expected = {
         filename,
-        data: { hello: "world" }
+        data: { hello: "world" },
       };
 
       expect(data).toEqual(expected);
@@ -29,7 +29,7 @@ describe(localNameOf(__filename), () => {
       const data = await readFile({ filename });
       const expected = {
         filename,
-        data: null
+        data: null,
       };
 
       expect(data).toEqual(expected);
@@ -44,7 +44,7 @@ describe(localNameOf(__filename), () => {
       const data = await readFile({ filename });
       const expected = {
         filename,
-        data: null
+        data: null,
       };
 
       expect(data).toEqual(expected);
@@ -54,7 +54,7 @@ describe(localNameOf(__filename), () => {
   test.each([
     "invalid-syntax.json",
     "invalid-syntax.yaml",
-    "invalid-syntax.yml"
+    "invalid-syntax.yml",
   ])("throws when configuration has invalid syntax: %s", async file => {
     let error;
 
@@ -83,7 +83,7 @@ describe(localNameOf(__filename), () => {
 
     const expected = {
       filename,
-      data: null
+      data: null,
     };
 
     expect(data).toEqual(expected);

--- a/packages/config/lib/index.js
+++ b/packages/config/lib/index.js
@@ -13,5 +13,7 @@ function withLogger(fn) {
   return wrapped;
 }
 
-exports.watchOne = withLogger(watchOne);
-exports.watchMany = withLogger(watchMany);
+module.exports = {
+  watchMany: withLogger(watchMany),
+  watchOne: withLogger(watchOne),
+};

--- a/packages/config/lib/watchMany.js
+++ b/packages/config/lib/watchMany.js
@@ -10,7 +10,7 @@ module.exports = function watchMany({
   dirname,
   glob,
   logger,
-  stabilityThreshold = 1000
+  stabilityThreshold = 1000,
 }) {
   assert(path.isAbsolute(dirname), `"${dirname}" is not an absolute path`);
 
@@ -67,7 +67,7 @@ module.exports = function watchMany({
     const options = {
       atomic: true,
       awaitWriteFinish: { stabilityThreshold },
-      persistent: true
+      persistent: true,
     };
 
     logger.debug(`Preparing to watch: ${pattern}`);

--- a/packages/config/lib/watchMany.spec.js
+++ b/packages/config/lib/watchMany.spec.js
@@ -18,7 +18,7 @@ describe(localNameOf(__filename), () => {
     },
     error(...args) {
       // console.error(...args);
-    }
+    },
   };
 
   const watch = params => {
@@ -40,19 +40,19 @@ describe(localNameOf(__filename), () => {
     const options = {
       postfix: ".json",
       discardDescriptor: true,
-      dir: dirname
+      dir: dirname,
     };
 
     let filename = tmp.fileSync(options).name;
     a = {
       filename,
-      glob: path.basename(filename)
+      glob: path.basename(filename),
     };
 
     filename = tmp.fileSync(options).name;
     b = {
       filename,
-      glob: path.basename(filename)
+      glob: path.basename(filename),
     };
   });
 
@@ -103,7 +103,7 @@ describe(localNameOf(__filename), () => {
       .subscribe(spy, null, () => {
         const expected = {
           isReady: true,
-          config: { data, filename: a.filename }
+          config: { data, filename: a.filename },
         };
         expect(spy.mock.calls[0]).toEqual([expected]);
         done();
@@ -207,7 +207,7 @@ describe(localNameOf(__filename), () => {
   describe("when reading file contents", () => {
     it("emits readConfig errors", done => {
       jest.mock("./helpers", () => ({
-        readConfig: () => Promise.reject(new Error("spec:watchMany"))
+        readConfig: () => Promise.reject(new Error("spec:watchMany")),
       }));
 
       subscriber = watch({ glob: a.glob }).subscribe(null, err => {

--- a/packages/config/lib/watchOne.js
+++ b/packages/config/lib/watchOne.js
@@ -10,6 +10,6 @@ module.exports = function watchOne({ filename, logger }) {
   return watchMany({
     dirname: path.dirname(filename),
     glob: path.basename(filename),
-    logger
+    logger,
   });
 };

--- a/packages/emitters/aliases.spec.js
+++ b/packages/emitters/aliases.spec.js
@@ -5,6 +5,6 @@ const { createExportAliasSpecs } = require("@finch/core-tools");
 
 describe(localNameOf(__filename), () => {
   createExportAliasSpecs({
-    exportDirectory: __dirname
+    exportDirectory: __dirname,
   });
 });

--- a/packages/logger/lib/index.js
+++ b/packages/logger/lib/index.js
@@ -14,7 +14,7 @@ const logger = createLogger({
     )
   ),
   level: "debug",
-  transports: [new transports.Console()]
+  transports: [new transports.Console()],
 });
 
 module.exports = function index(prefix) {

--- a/packages/operators/aliases.spec.js
+++ b/packages/operators/aliases.spec.js
@@ -5,6 +5,6 @@ const { createExportAliasSpecs } = require("@finch/core-tools");
 
 describe(localNameOf(__filename), () => {
   createExportAliasSpecs({
-    exportDirectory: __dirname
+    exportDirectory: __dirname,
   });
 });

--- a/packages/operators/lib/regexp-blacklist/index.spec.js
+++ b/packages/operators/lib/regexp-blacklist/index.spec.js
@@ -80,8 +80,8 @@ describe(localNameOf(__filename), () => {
         value,
         params: {
           all: [/\w+/],
-          any: [/z/, /a/]
-        }
+          any: [/z/, /a/],
+        },
       });
 
       return expect(promise).resolves.toBe(empty());
@@ -92,8 +92,8 @@ describe(localNameOf(__filename), () => {
         value,
         params: {
           all: [/\w+/],
-          any: [/z/]
-        }
+          any: [/z/],
+        },
       });
 
       expect(promise).resolves.toBe(value);

--- a/packages/operators/lib/regexp-whitelist/index.spec.js
+++ b/packages/operators/lib/regexp-whitelist/index.spec.js
@@ -80,8 +80,8 @@ describe(localNameOf(__filename), () => {
         value,
         params: {
           all: [/\w+/],
-          any: [/z/, /a/]
-        }
+          any: [/z/, /a/],
+        },
       });
 
       return expect(promise).resolves.toBe(value);
@@ -92,8 +92,8 @@ describe(localNameOf(__filename), () => {
         value,
         params: {
           all: [/\w+/],
-          any: [/z/]
-        }
+          any: [/z/],
+        },
       });
 
       return expect(promise).resolves.toBe(empty());

--- a/packages/stream/lib/empty.js
+++ b/packages/stream/lib/empty.js
@@ -5,8 +5,10 @@
 const secret =
   "op8o2MoSpgSxMRikPFdjixbAFz2ucZ5LtvuLU2bTzoCguX53dxfbAnpKfiv3uziu";
 
-module.exports = () => secret;
+const exported = () => secret;
 
 if (process.env.NODE_ENV === "test") {
-  module.exports.__secret__ = secret;
+  exported.__secret__ = secret;
 }
+
+module.exports = exported;

--- a/packages/stream/lib/helpers/createOperator.js
+++ b/packages/stream/lib/helpers/createOperator.js
@@ -22,11 +22,12 @@ module.exports = function createOperator(stage, context) {
     retryWait >= 0 &&
     retryBackoff({
       initialInterval: retryWait,
-      maxRetries: retryCount
+      maxRetries: retryCount,
     });
 
   return function(source) {
     const operator = mergeMap(value => {
+      // Uh-oh, value can be an array and should be frozen.
       const immutableValue = isPlainObject(value)
         ? deepFreeze(cloneDeep(value))
         : value;
@@ -34,7 +35,7 @@ module.exports = function createOperator(stage, context) {
       const payload = Object.freeze({
         value: immutableValue,
         params: immutableParams,
-        context
+        context,
       });
 
       const operators = [];

--- a/packages/stream/lib/helpers/createOperator.spec.js
+++ b/packages/stream/lib/helpers/createOperator.spec.js
@@ -118,7 +118,7 @@ describe(localNameOf(__filename), () => {
     const operator = createOperator(
       {
         use: promiseResolveIdentityMutateParams,
-        params
+        params,
       },
       context
     );
@@ -152,7 +152,7 @@ describe(localNameOf(__filename), () => {
     const operator = createOperator(
       {
         use: promiseResolveIdentityMutateIdentity,
-        params
+        params,
       },
       context
     );
@@ -199,7 +199,7 @@ describe(localNameOf(__filename), () => {
     const operator = createOperator(
       {
         use: stringSplit,
-        params: { glue: "," }
+        params: { glue: "," },
       },
       context
     );
@@ -313,7 +313,7 @@ describe(localNameOf(__filename), () => {
     const operator = createOperator(
       {
         use: asyncAwaitThrow,
-        continueOnError: false
+        continueOnError: false,
       },
       context
     );
@@ -328,7 +328,7 @@ describe(localNameOf(__filename), () => {
     const operator = createOperator(
       {
         use: promiseResolveIfEvenElseReject,
-        continueOnError: false
+        continueOnError: false,
       },
       context
     );
@@ -348,7 +348,7 @@ describe(localNameOf(__filename), () => {
       {
         use: spyPromiseResolveIfEvenElseReject,
         retryCount,
-        retryWait
+        retryWait,
       },
       context
     );
@@ -366,7 +366,7 @@ describe(localNameOf(__filename), () => {
           [{ context, params: {}, value: "meaning of life" }],
           [{ context, params: {}, value: 42 }],
           [{ context, params: {}, value: "meaning of life" }],
-          [{ context, params: {}, value: "meaning of life" }]
+          [{ context, params: {}, value: "meaning of life" }],
         ]);
 
         done();

--- a/packages/stream/lib/index.js
+++ b/packages/stream/lib/index.js
@@ -1,5 +1,5 @@
 "use strict";
 
 module.exports = require("@mseeley/export-from")(__dirname, {
-  excludes: ["helpers/**"]
+  excludes: ["helpers/**"],
 });

--- a/packages/stream/lib/validateStages.js
+++ b/packages/stream/lib/validateStages.js
@@ -13,7 +13,7 @@ function reduceErrors(errors) {
       error.keyword === KEYWORD_ADDITIONAL_PROPERTIES
         ? {
             ...error,
-            message: `${error.message}: ${error.params.additionalProperty}`
+            message: `${error.message}: ${error.params.additionalProperty}`,
           }
         : error
     )
@@ -23,7 +23,7 @@ function reduceErrors(errors) {
       if (!errorAtPointer) {
         errorAtPointer = {
           pointer: error.dataPath,
-          errors: []
+          errors: [],
         };
 
         acc.push(errorAtPointer);

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  endOfLine: "lf"
+  endOfLine: "lf",
+  trailingComma: "es5",
 };

--- a/scripts/create-cli.js
+++ b/scripts/create-cli.js
@@ -9,7 +9,7 @@ async function main() {
     const settings = await inquirer.prompt([
       questions.packageNameToOrgScopeNotExists,
       questions.packageDescription,
-      questions.isPrivate
+      questions.isPrivate,
     ]);
 
     await create(settings);

--- a/scripts/workspace/create.js
+++ b/scripts/workspace/create.js
@@ -5,7 +5,7 @@ const {
   readReadme,
   resolvePackage,
   writePackageJson,
-  writeReadme
+  writeReadme,
 } = require("./helpers");
 
 async function copyTemplate({ packageName }) {
@@ -26,7 +26,7 @@ async function copyTemplate({ packageName }) {
 async function updatePackageJson({
   isPrivate,
   packageDescription,
-  packageName
+  packageName,
 }) {
   const json = await readPackageJson({ packageName });
 

--- a/scripts/workspace/helpers/findOtherPackagesInScope.js
+++ b/scripts/workspace/helpers/findOtherPackagesInScope.js
@@ -2,7 +2,7 @@ const findPackagesInScope = require("./findPackagesInScope");
 
 module.exports = async function findOtherPackagesInScope({
   packageName,
-  scope
+  scope,
 }) {
   const packages = await findPackagesInScope({ scope });
   return packages.filter(p => p !== packageName);

--- a/scripts/workspace/helpers/parsePackageName.js
+++ b/scripts/workspace/helpers/parsePackageName.js
@@ -17,6 +17,6 @@ module.exports = async function({ packageName }) {
   return {
     ...parsed,
     scope,
-    package
+    package,
   };
 };

--- a/scripts/workspace/questions.js
+++ b/scripts/workspace/questions.js
@@ -3,7 +3,7 @@ const {
   hasOrgScope,
   findPackagesInScope,
   getOrgScopeAll,
-  toOrgScope
+  toOrgScope,
 } = require("./helpers");
 
 // Factories
@@ -120,29 +120,29 @@ question("packageName", {
   type: "input",
   message: "Package:",
   filter: [filterSanitizeString],
-  validate: [validateString, validatePackageName]
+  validate: [validateString, validatePackageName],
 });
 
 question("packageNameToOrgScope", {
   extends: "packageName",
-  filter: [filterSanitizeString, filterTryToOrgScope]
+  filter: [filterSanitizeString, filterTryToOrgScope],
 });
 
 question("packageNameToOrgScopeExists", {
   extends: "packageNameToOrgScope",
-  validate: [validateString, validatePackageName, validatePackageExists]
+  validate: [validateString, validatePackageName, validatePackageExists],
 });
 
 question("packageNameToOrgScopeNotExists", {
   extends: "packageNameToOrgScope",
-  validate: [validateString, validatePackageName, validatePackageNotExists]
+  validate: [validateString, validatePackageName, validatePackageNotExists],
 });
 
 question("packageDescription", {
   type: "input",
   message: "Description:",
   filter: [filterSanitizeString],
-  validate: [validateString]
+  validate: [validateString],
 });
 
 question("lernaScopeExists", {
@@ -150,7 +150,7 @@ question("lernaScopeExists", {
   name: "scope",
   message: `Scope:`,
   default: getOrgScopeAll,
-  validate: [validateString, validateLernaScope]
+  validate: [validateString, validateLernaScope],
 });
 
 question("confirmPackageName", {
@@ -159,8 +159,8 @@ question("confirmPackageName", {
   filter: [filterSanitizeString],
   validate: [
     validateString,
-    async (value, answers) => value === answers.packageName
-  ]
+    async (value, answers) => value === answers.packageName,
+  ],
 });
 
 // Confirm
@@ -168,5 +168,5 @@ question("confirmPackageName", {
 question("isPrivate", {
   type: "confirm",
   message: "Private package?",
-  default: false
+  default: false,
 });

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -2,6 +2,6 @@ module.exports = {
   extends: ["stylelint-config-recommended", "stylelint-config-prettier"],
   plugins: ["stylelint-prettier"],
   rules: {
-    "prettier/prettier": true
-  }
+    "prettier/prettier": true,
+  },
 };


### PR DESCRIPTION
- Prettier now enforces es5 trailing commas.
- ESLint now enforces that modules expose a single export